### PR TITLE
Remove (unused) property names.

### DIFF
--- a/src/LogDensityProblems.jl
+++ b/src/LogDensityProblems.jl
@@ -1,6 +1,7 @@
 module LogDensityProblems
 
-export logdensity, dimension, TransformedLogDensity, reject_logdensity, ADgradient
+export logdensity, dimension, TransformedLogDensity, get_transformation, reject_logdensity,
+    ADgradient, get_parent
 
 import Base: eltype, isfinite, isinf, show
 
@@ -150,6 +151,8 @@ end
 show(io::IO, ℓ::TransformedLogDensity) =
     print(io, "TransformedLogDensity of dimension $(dimension(ℓ.transformation))")
 
+get_transformation(p::TransformedLogDensity) = p.transformation
+
 """
 $(SIGNATURES)
 
@@ -177,12 +180,12 @@ An abstract type that wraps another log density in its field `ℓ`.
 # Notes
 
 Implementation detail, *not exported*.
-
-Forwards properties other than its field names to `ℓ`.
 """
 abstract type LogDensityWrapper <: AbstractLogDensityProblem end
 
-dimension(w::LogDensityWrapper) = dimension(w.ℓ)
+get_parent(w::LogDensityWrapper) = w.ℓ
+
+dimension(w::LogDensityWrapper) = dimension(get_parent(w))
 
 """
 An abstract type that wraps another log density for calculating the gradient via AD.

--- a/src/LogDensityProblems.jl
+++ b/src/LogDensityProblems.jl
@@ -2,7 +2,7 @@ module LogDensityProblems
 
 export logdensity, dimension, TransformedLogDensity, reject_logdensity, ADgradient
 
-import Base: eltype, getproperty, propertynames, isfinite, isinf, show
+import Base: eltype, isfinite, isinf, show
 
 using ArgCheck: @argcheck
 using BenchmarkTools: @belapsed
@@ -183,17 +183,6 @@ Forwards properties other than its field names to `ℓ`.
 abstract type LogDensityWrapper <: AbstractLogDensityProblem end
 
 dimension(w::LogDensityWrapper) = dimension(w.ℓ)
-
-propertynames(w::LogDensityWrapper) =
-    unique((fieldnames(typeof(w))..., propertynames(w.ℓ)...))
-
-function getproperty(w::LogDensityWrapper, name::Symbol)
-    if name ∈ fieldnames(typeof(w))
-        getfield(w, name)
-    else
-        getproperty(w.ℓ, name)
-    end
-end
 
 """
 An abstract type that wraps another log density for calculating the gradient via AD.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,12 +51,12 @@ end
     # a Bayesian problem
     p = TransformedLogDensity(t, logposterior)
     @test dimension(p) == 1
-    @test p.transformation ≡ t
+    @test get_transformation(p) ≡ t
 
     # gradient of a problem
     ∇p = ADgradient(:ForwardDiff, p)
     @test dimension(∇p) == 1
-    @test ∇p.transformation ≡ t
+    @test get_transformation(get_parent(∇p)) ≡ t
 
     for _ in 1:100
         x = random_arg(p)
@@ -77,7 +77,7 @@ end
     ∇p = ADgradient(:ForwardDiff, p)
 
     @test dimension(p) == dimension(∇p) == dimension(t)
-    @test p.transformation ≡ ∇p.transformation ≡ t
+    @test get_transformation(p) ≡ get_transformation(get_parent(∇p)) ≡ t
 
     for _ in 1:100
         x = random_arg(p)


### PR DESCRIPTION
The implementation was preventing some type inference, and it was not used anyway.