### PR TITLE
Code style and API cleanup.

### DIFF
--- a/src/AD_Flux.jl
+++ b/src/AD_Flux.jl
@@ -11,7 +11,7 @@ Gradient using algorithmic/automatic differentiation via Flux.
 """
 ADgradient(::Val{:Flux}, ℓ) = FluxGradientLogDensity(ℓ)
 
-show(io::IO, ∇ℓ::FluxGradientLogDensity) = print(io, "Flux AD wrapper for ", ∇ℓ.ℓ)
+Base.show(io::IO, ∇ℓ::FluxGradientLogDensity) = print(io, "Flux AD wrapper for ", ∇ℓ.ℓ)
 
 function logdensity(::Type{ValueGradient}, ∇ℓ::FluxGradientLogDensity, x::RealVector)
     @unpack ℓ = ∇ℓ

--- a/src/AD_ForwardDiff.jl
+++ b/src/AD_ForwardDiff.jl
@@ -8,7 +8,7 @@ struct ForwardDiffLogDensity{L, C} <: ADGradientWrapper
     gradientconfig::C
 end
 
-function show(io::IO, ℓ::ForwardDiffLogDensity)
+function Base.show(io::IO, ℓ::ForwardDiffLogDensity)
     print(io, "ForwardDiff AD wrapper for ", ℓ.ℓ,
           ", w/ chunk size ", length(ℓ.gradientconfig.seeds))
 end

--- a/src/AD_ReverseDiff.jl
+++ b/src/AD_ReverseDiff.jl
@@ -5,7 +5,7 @@ struct ReverseDiffLogDensity{L, C} <: ADGradientWrapper
     gradientconfig::C
 end
 
-show(io::IO, ℓ::ReverseDiffLogDensity) = print(io, "ReverseDiff AD wrapper for ", ℓ.ℓ)
+Base.show(io::IO, ℓ::ReverseDiffLogDensity) = print(io, "ReverseDiff AD wrapper for ", ℓ.ℓ)
 
 function logdensity(::Type{ValueGradient}, fℓ::ReverseDiffLogDensity, x::RealVector)
     @unpack ℓ, gradientconfig = fℓ
@@ -20,7 +20,9 @@ struct ReverseDiffTapeLogDensity{L, R, T} <: ADGradientWrapper
     compiled_tape::T
 end
 
-show(io::IO, ℓ::ReverseDiffTapeLogDensity) = print(io, "ReverseDiff AD wrapper (compiled tape) for ", ℓ.ℓ)
+function Base.show(io::IO, ℓ::ReverseDiffTapeLogDensity)
+    print(io, "ReverseDiff AD wrapper (compiled tape) for ", ℓ.ℓ)
+end
 
 function logdensity(::Type{ValueGradient}, fℓ::ReverseDiffTapeLogDensity, x::RealVector)
     @unpack result_buffer, compiled_tape = fℓ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,12 +51,12 @@ end
     # a Bayesian problem
     p = TransformedLogDensity(t, logposterior)
     @test dimension(p) == 1
-    @test get_transformation(p) ≡ t
+    @test p.transformation ≡ t
 
     # gradient of a problem
     ∇p = ADgradient(:ForwardDiff, p)
     @test dimension(∇p) == 1
-    @test get_transformation(get_parent(∇p)) ≡ t
+    @test parent(∇p).transformation ≡ t
 
     for _ in 1:100
         x = random_arg(p)
@@ -77,7 +77,7 @@ end
     ∇p = ADgradient(:ForwardDiff, p)
 
     @test dimension(p) == dimension(∇p) == dimension(t)
-    @test get_transformation(p) ≡ get_transformation(get_parent(∇p)) ≡ t
+    @test p.transformation ≡ parent(∇p).transformation ≡ t
 
     for _ in 1:100
         x = random_arg(p)


### PR DESCRIPTION
API changes:

1. remove `get_parent` (replaced by `Base.parent`),

2. remove `get_transformation` (replaced by the property accessor
`.transformation`); similary support `.log_density_function`

Code style changes:

Don't import extended methods, more consistent formatting.