### PR TITLE
remove taped reversediff

### DIFF
--- a/src/AD_ReverseDiff.jl
+++ b/src/AD_ReverseDiff.jl
@@ -14,37 +14,13 @@ function logdensity(vgb::ValueGradientBuffer, fℓ::ReverseDiffLogDensity, x::Ab
     ValueGradient(result)
 end
 
-struct ReverseDiffTapeLogDensity{L, T} <: ADGradientWrapper
-    ℓ::L
-    compiled_tape::T
-end
-
-function Base.show(io::IO, ℓ::ReverseDiffTapeLogDensity)
-    print(io, "ReverseDiff AD wrapper (compiled tape) for ", ℓ.ℓ)
-end
-
-function logdensity(vgb::ValueGradientBuffer, fℓ::ReverseDiffTapeLogDensity,
-                    x::AbstractVector)
-    @unpack compiled_tape = fℓ
-    result = ReverseDiff.gradient!(DiffResults.MutableDiffResult(vgb), compiled_tape, x)
-    ValueGradient(result)
-end
-
 """
 $(SIGNATURES)
 
-AD via ReverseDiff. When `tape`, record and compile a tape; usual caveats apply, see the
-ReverseDiff documentation.
+AD via ReverseDiff.
 """
-function ADgradient(::Val{:ReverseDiff}, ℓ; tape = false)
+function ADgradient(::Val{:ReverseDiff}, ℓ)
     z = zeros(dimension(ℓ))
-    if tape
-        f = _logdensity_closure(ℓ)
-        tape = ReverseDiff.GradientTape(f, z)
-        compiled_tape = ReverseDiff.compile(tape)
-        ReverseDiffTapeLogDensity(ℓ, compiled_tape)
-    else
-        cfg = ReverseDiff.GradientConfig(z)
-        ReverseDiffLogDensity(ℓ, cfg)
-    end
+    cfg = ReverseDiff.GradientConfig(z)
+    ReverseDiffLogDensity(ℓ, cfg)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,8 +147,6 @@ end
     @test repr(ADgradient(:ForwardDiff, p; chunk = 2)) ==
         ("ForwardDiff AD wrapper for " * repr(p) * ", w/ chunk size 2")
     @test repr(ADgradient(:ReverseDiff, p)) == ("ReverseDiff AD wrapper for " * repr(p))
-    @test repr(ADgradient(:ReverseDiff, p; tape = true)) ==
-        ("ReverseDiff AD wrapper (compiled tape) for " * repr(p))
     @test repr(ADgradient(:Flux, p)) == ("Flux AD wrapper for " * repr(p))
 end
 


### PR DESCRIPTION
Don't provide a ReverseDiff wrapper with precompiled tapes. They can be very fragile since branches are not possible to eliminate in practice for most log density problems.