### PR TITLE
Docs: Clarify statement about the API

### DIFF
--- a/src/LogDensityProblems.jl
+++ b/src/LogDensityProblems.jl
@@ -142,7 +142,7 @@ methods recommend using `transformation` to avoid this. It is recommended that
 `log_density_function` is a callable object that also encapsulates the data for the problem.
 
 Use the property accessors `ℓ.transformation` and `ℓ.log_density_function` to access the
-arguments of `ℓ::TransformedLogDensity`, these are part of the API.
+arguments of `ℓ::TransformedLogDensity`, these are part of the stable public API.
 
 # Usage note
 

--- a/src/LogDensityProblems.jl
+++ b/src/LogDensityProblems.jl
@@ -142,7 +142,7 @@ methods recommend using `transformation` to avoid this. It is recommended that
 `log_density_function` is a callable object that also encapsulates the data for the problem.
 
 Use the property accessors `ℓ.transformation` and `ℓ.log_density_function` to access the
-arguments of `ℓ::TransformedLogDensity`, these are part of the stable public API.
+arguments of `ℓ::TransformedLogDensity`, these are part of the public API.
 
 # Usage note
 


### PR DESCRIPTION
If I understand correctly, if I have an object of type `TransformedLogDensity`, then the official way of getting the `transformation` or `log_density_function` fields is by doing `ℓ.transformation` or `ℓ.log_density_function`, respectively.

This pull request edits the docstring for `TransformedLogDensity` to emphasize that this is part of the stable public API and will not change in a non-breaking release.