### PR TITLE
add ReverseDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 
 [targets]
-test = ["Distributions", "Documenter", "ForwardDiff", "Test", "StatsBase", "StatsFuns", "Tracker", "Zygote"]
+test = ["Distributions", "Documenter", "ForwardDiff", "Test", "StatsBase", "StatsFuns", "Tracker", "Zygote", "ReverseDiff"]

--- a/src/AD_ReverseDiff.jl
+++ b/src/AD_ReverseDiff.jl
@@ -1,0 +1,34 @@
+#####
+##### Gradient AD implementation using ReverseDiff
+#####
+
+import .ReverseDiff
+
+struct ReverseDiffLogDensity{L, C} <: ADGradientWrapper
+    ℓ::L
+	compiledtape::C
+end
+
+"""
+    ADgradient(:ReverseDiff, ℓ)
+    ADgradient(Val(:ReverseDiff), ℓ)
+
+Gradient using algorithmic/automatic differentiation via ReverseDiff.
+"""
+ADgradient(::Val{:ReverseDiff}, ℓ) = begin
+	f = _logdensity_closure(ℓ)
+	x = rand(dimension(ℓ)) #init random parameters
+	tape = ReverseDiff.GradientTape(f, x)
+	compiledtape = ReverseDiff.compile(tape)
+	ReverseDiffLogDensity(ℓ, compiledtape)
+end
+
+Base.show(io::IO, ∇ℓ::ReverseDiffLogDensity) = print(io, "ReverseDiff AD wrapper for ", ∇ℓ.ℓ)
+
+function logdensity_and_gradient(∇ℓ::ReverseDiffLogDensity, x::AbstractVector{T}) where {T}
+    @unpack ℓ, compiledtape = ∇ℓ
+
+	buffer = _diffresults_buffer(ℓ, x)
+    result = ReverseDiff.gradient!(buffer, compiledtape, x)
+    _diffresults_extract(result)
+end

--- a/src/LogDensityProblems.jl
+++ b/src/LogDensityProblems.jl
@@ -229,6 +229,7 @@ function __init__()
     @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" include("AD_ForwardDiff.jl")
     @require Tracker="9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" include("AD_Tracker.jl")
     @require Zygote="e88e6eb3-aa80-5325-afca-941959d7151f" include("AD_Zygote.jl")
+    @require ReverseDiff="37e2e3b7-166d-5795-8a7a-e32c996b4267" include("AD_ReverseDiff.jl")
 end
 
 ####


### PR DESCRIPTION
Hi @tpapp,

this is related to #75. As I understand, ReverseDiff cannot deal with run-time if statements (at least when using the compiled tape) and therefore tests pass only with `test_logdensity1` but not with `test_logdensity`. 