### PR TITLE
ReverseDiff: Do not always compile tape

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblems"
 uuid = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.11.4"
+version = "0.11.5"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/AD_ReverseDiff.jl
+++ b/src/AD_ReverseDiff.jl
@@ -10,10 +10,21 @@ struct ReverseDiffLogDensity{L,C} <: ADGradientWrapper
 end
 
 """
-    ADgradient(:ReverseDiff, ℓ)
-    ADgradient(Val(:ReverseDiff), ℓ)
+    ADgradient(:ReverseDiff, ℓ; compile=Val(false), x=nothing)
+    ADgradient(Val(:ReverseDiff), ℓ; compile=Val(false), x=nothing)
 
 Gradient using algorithmic/automatic differentiation via ReverseDiff.
+
+If `compile isa Val{true}`, a tape of the log density computation is created upon construction of the gradient function and used in every evaluation of the gradient.
+One may provide an example input `x::AbstractVector` of the log density function.
+If `x` is `nothing` (the default), the tape is created with input `zeros(dimension(ℓ))`.
+
+By default, no tape is created.
+
+!!! note
+    Using a compiled tape can lead to significant performance improvements when the gradient of the log density
+    is evaluated multiple times (possibly for different inputs).
+    However, if the log density contains branches, use of a compiled tape can lead to silently incorrect results.
 """
 function ADgradient(::Val{:ReverseDiff}, ℓ;
                     compile::Union{Val{true},Val{false}}=Val(false), x::Union{Nothing,AbstractVector}=nothing)


### PR DESCRIPTION
It's nice - and very efficient - to pre-compute and compile tapes with ReverseDiff whenever possible. Unfortunately, if there is some branching it leads to incorrect derivatives. This is even the case for the example in the tests. A simpler example that demonstrates the issue:
```julia
julia> using ReverseDiff                                   
                                                           
julia> f(x) = x < zero(x) ? zero(x) : x   
f (generic function with 1 method)   

julia> ReverseDiff.gradient(f ∘ only, [-1.23])
1-element Vector{Float64}:
 0.0

julia> ReverseDiff.gradient(f ∘ only, [1.41])
1-element Vector{Float64}:
 1.0

julia> tape = ReverseDiff.GradientTape(f, [-1.3])
typename(ReverseDiff.GradientTape)(f)

julia> ReverseDiff.gradient!(tape, [1.34])
1-element Vector{Float64}:
 0.0

julia> ReverseDiff.gradient!(tape, [-0.2])
1-element Vector{Float64}:
 0.0

julia> compiledtape = ReverseDiff.compile(tape)
typename(ReverseDiff.CompiledTape)(f)

julia> ReverseDiff.gradient!(tape, [1.34])
1-element Vector{Float64}:
 0.0

julia> ReverseDiff.gradient!(tape, [-0.2])
1-element Vector{Float64}:
 0.0
```

Thus I suggest to not use compiled tapes by default (alternatively, one could use something like https://github.com/SciML/SciMLSensitivity.jl/blob/4a608f15413e5fdedd9939093d97d5cd982205f6/src/hasbranching.jl to determine if the function has branches but that seems a bit too dependency-heavy for LogDensityProblems, I assume).

The PR adds a (default) option for not compiling the tape and support for ReverseDiff without tapes.