### PR TITLE
Use `Base.Fix1` instead of `_logdensity_closure`

### DIFF
--- a/src/AD_ForwardDiff.jl
+++ b/src/AD_ForwardDiff.jl
@@ -16,11 +16,8 @@ end
 
 _default_chunk(ℓ) = ForwardDiff.Chunk(dimension(ℓ))
 
-# defined to make the tag match
-_logdensity_closure(ℓ) = x -> logdensity(ℓ, x)
-
 function _default_gradientconfig(ℓ, chunk::ForwardDiff.Chunk)
-    ForwardDiff.GradientConfig(_logdensity_closure(ℓ), zeros(dimension(ℓ)), chunk)
+    ForwardDiff.GradientConfig(Base.Fix1(logdensity, ℓ), zeros(dimension(ℓ)), chunk)
 end
 
 function _default_gradientconfig(ℓ, chunk::Integer)
@@ -47,6 +44,6 @@ end
 function logdensity_and_gradient(fℓ::ForwardDiffLogDensity, x::AbstractVector)
     @unpack ℓ, gradientconfig = fℓ
     buffer = _diffresults_buffer(ℓ, x)
-    result = ForwardDiff.gradient!(buffer, _logdensity_closure(ℓ), x, gradientconfig)
+    result = ForwardDiff.gradient!(buffer, Base.Fix1(logdensity, ℓ), x, gradientconfig)
     _diffresults_extract(result)
 end

--- a/src/AD_Zygote.jl
+++ b/src/AD_Zygote.jl
@@ -16,6 +16,6 @@ Base.show(io::IO, ∇ℓ::ZygoteGradientLogDensity) = print(io, "Zygote AD wrapp
 
 function logdensity_and_gradient(∇ℓ::ZygoteGradientLogDensity, x::AbstractVector)
     @unpack ℓ = ∇ℓ
-    y, back = Zygote.pullback(_logdensity_closure(ℓ), x)
+    y, back = Zygote.pullback(Base.Fix1(logdensity, ℓ), x)
     y, first(back(Zygote.sensitivity(y)))
 end


### PR DESCRIPTION
The motivation for this PR is that I don't know how to allow custom ForwardDiff tags with `ForwardDiff.checktag` (such as in https://github.com/TuringLang/Turing.jl/blob/c0c8bc2af0fa32621ded96afcd3ba1cfabd686aa/src/Turing.jl#L45) with the current `_logdensity_closure` setup as I don't know how to get the supertype of the result of `_logdensity_closure(::MyParameterizedStruct)` without evaluating `_logdensity_closure`. With `Base.Fix1`, however, I can easily define `ForwardDiff.checktag(::Type{MyTag{V}}, ::Base.Fix1{typeof(logdensity),<:MyParameterizedStruct}, ::AbstractVector{V})` and thereby limit the custom tags to the intended use case.

An additional "fix" in this PR: Currently the Zygote backend uses `_logdensity_closure` as well which is only defined in the optionally loaded ForwardDiff backend. That works because Zygote depends on and loads ForwardDiff but probably it is safer to not having to rely on such internals.