### PR TITLE
Experimental: switch to DensityInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.12.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StaticNumbers = "c5e4b96a-f99f-5557-8ed2-dc63ef9b5131"
 TransformVariables = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 

--- a/src/AD_Enzyme.jl
+++ b/src/AD_Enzyme.jl
@@ -19,7 +19,7 @@ Gradient using algorithmic/automatic differentiation via Enzyme.
 
 - `shadow`: Collection of one-hot vectors for each entry of the inputs `x` to the log density
   `ℓ`, or `nothing` (default: `nothing`). This keyword argument is only used in forward
-  mode. By default, it will be recomputed in every call of `logdensity_and_gradient(ℓ, x)`.
+  mode. By default, it will be recomputed in every call of `logdensity_and_gradient_of(ℓ, x)`.
   For performance reasons it is recommended to compute it only once when calling `ADgradient`.
   The one-hot vectors can be constructed, e.g., with `Enzyme.onehot(x)`.
 """
@@ -39,23 +39,23 @@ function Base.show(io::IO, ∇ℓ::EnzymeGradientLogDensity)
           ∇ℓ.mode isa Enzyme.ForwardMode ? "forward" : "reverse", " mode")
 end
 
-function logdensity_and_gradient(∇ℓ::EnzymeGradientLogDensity{<:Any,<:Enzyme.ForwardMode},
+function logdensity_and_gradient_of(∇ℓ::EnzymeGradientLogDensity{<:Any,<:Enzyme.ForwardMode},
                                  x::AbstractVector)
     @unpack ℓ, mode, shadow = ∇ℓ
     _shadow = shadow === nothing ? Enzyme.onehot(x) : shadow
-    y, ∂ℓ_∂x = Enzyme.autodiff(mode, Base.Fix1(logdensity, ℓ), Enzyme.BatchDuplicated,
+    y, ∂ℓ_∂x = Enzyme.autodiff(mode, logdensityof(ℓ), Enzyme.BatchDuplicated,
                                Enzyme.BatchDuplicated(x, _shadow))
     return y, collect(∂ℓ_∂x)
 end
 
-function logdensity_and_gradient(∇ℓ::EnzymeGradientLogDensity{<:Any,<:Enzyme.ReverseMode},
+function logdensity_and_gradient_of(∇ℓ::EnzymeGradientLogDensity{<:Any,<:Enzyme.ReverseMode},
                                  x::AbstractVector)
     @unpack ℓ, mode = ∇ℓ
     # Currently it is not possible to retrieve the primal together with the derivatives.
     # Ref: https://github.com/EnzymeAD/Enzyme.jl/issues/107
-    y = logdensity(ℓ, x)
+    y = logdensityof(ℓ, x)
     ∂ℓ_∂x = zero(x)
-    Enzyme.autodiff(mode, Base.Fix1(logdensity, ℓ), Enzyme.Active,
+    Enzyme.autodiff(mode, logdensityof(ℓ), Enzyme.Active,
                     Enzyme.Duplicated(x, ∂ℓ_∂x))
     y, ∂ℓ_∂x
 end

--- a/src/AD_ForwardDiff.jl
+++ b/src/AD_ForwardDiff.jl
@@ -17,7 +17,7 @@ end
 _default_chunk(ℓ) = ForwardDiff.Chunk(dimension(ℓ))
 
 function _default_gradientconfig(ℓ, chunk::ForwardDiff.Chunk)
-    ForwardDiff.GradientConfig(Base.Fix1(logdensity, ℓ), zeros(dimension(ℓ)), chunk)
+    ForwardDiff.GradientConfig(logdensityof(ℓ), zeros(dimension(ℓ)), chunk)
 end
 
 function _default_gradientconfig(ℓ, chunk::Integer)
@@ -41,9 +41,9 @@ function ADgradient(::Val{:ForwardDiff}, ℓ;
     ForwardDiffLogDensity(ℓ, gradientconfig)
 end
 
-function logdensity_and_gradient(fℓ::ForwardDiffLogDensity, x::AbstractVector)
+function logdensity_and_gradient_of(fℓ::ForwardDiffLogDensity, x::AbstractVector)
     @unpack ℓ, gradientconfig = fℓ
     buffer = _diffresults_buffer(ℓ, x)
-    result = ForwardDiff.gradient!(buffer, Base.Fix1(logdensity, ℓ), x, gradientconfig)
+    result = ForwardDiff.gradient!(buffer, logdensityof(ℓ), x, gradientconfig)
     _diffresults_extract(result)
 end

--- a/src/AD_ReverseDiff.jl
+++ b/src/AD_ReverseDiff.jl
@@ -34,7 +34,7 @@ end
 _compiledtape(ℓ, compile, x) = nothing
 _compiledtape(ℓ, ::Val{true}, ::Nothing) = _compiledtape(ℓ, Val(true), zeros(dimension(ℓ)))
 function _compiledtape(ℓ, ::Val{true}, x)
-    tape = ReverseDiff.GradientTape(Base.Fix1(logdensity, ℓ), x)
+    tape = ReverseDiff.GradientTape(logdensityof(ℓ), x)
     return ReverseDiff.compile(tape)
 end
 
@@ -46,11 +46,11 @@ function Base.show(io::IO, ∇ℓ::ReverseDiffLogDensity)
     print(io, "compiled tape)")
 end
 
-function logdensity_and_gradient(∇ℓ::ReverseDiffLogDensity, x::AbstractVector)
+function logdensity_and_gradient_of(∇ℓ::ReverseDiffLogDensity, x::AbstractVector)
     @unpack ℓ, compiledtape = ∇ℓ
     buffer = _diffresults_buffer(ℓ, x)
     if compiledtape === nothing
-        result = ReverseDiff.gradient!(buffer, Base.Fix1(logdensity, ℓ), x)
+        result = ReverseDiff.gradient!(buffer, logdensityof(ℓ), x)
     else
         result = ReverseDiff.gradient!(buffer, compiledtape, x)
     end

--- a/src/AD_Tracker.jl
+++ b/src/AD_Tracker.jl
@@ -20,9 +20,9 @@ ADgradient(::Val{:Tracker}, ℓ) = TrackerGradientLogDensity(ℓ)
 
 Base.show(io::IO, ∇ℓ::TrackerGradientLogDensity) = print(io, "Tracker AD wrapper for ", ∇ℓ.ℓ)
 
-function logdensity_and_gradient(∇ℓ::TrackerGradientLogDensity, x::AbstractVector{T}) where {T}
+function logdensity_and_gradient_of(∇ℓ::TrackerGradientLogDensity, x::AbstractVector{T}) where {T}
     @unpack ℓ = ∇ℓ
-    y, back = Tracker.forward(x -> logdensity(ℓ, x), x)
+    y, back = Tracker.forward(logdensityof(ℓ), x)
     yval = Tracker.data(y)
     # work around https://github.com/FluxML/Flux.jl/issues/497
     z = T <: Real ? zero(T) : 0.0

--- a/src/AD_Zygote.jl
+++ b/src/AD_Zygote.jl
@@ -14,8 +14,8 @@ ADgradient(::Val{:Zygote}, ℓ) = ZygoteGradientLogDensity(ℓ)
 
 Base.show(io::IO, ∇ℓ::ZygoteGradientLogDensity) = print(io, "Zygote AD wrapper for ", ∇ℓ.ℓ)
 
-function logdensity_and_gradient(∇ℓ::ZygoteGradientLogDensity, x::AbstractVector)
+function logdensity_and_gradient_of(∇ℓ::ZygoteGradientLogDensity, x::AbstractVector)
     @unpack ℓ = ∇ℓ
-    y, back = Zygote.pullback(Base.Fix1(logdensity, ℓ), x)
+    y, back = Zygote.pullback(logdensityof(ℓ), x)
     y, first(back(Zygote.sensitivity(y)))
 end

--- a/src/DiffResults_helpers.jl
+++ b/src/DiffResults_helpers.jl
@@ -20,7 +20,7 @@ end
 """
 $(SIGNATURES)
 
-Extract a return value for [`logdensity_and_gradient`](@ref) from a DiffResults buffer,
+Extract a return value for [`logdensity_and_gradient_of`](@ref) from a DiffResults buffer,
 constructed with [`diffresults_buffer`](@ref). Gradient is not copied as caller created the
 vector.
 """

--- a/src/ForwardDiff_benchmarking.jl
+++ b/src/ForwardDiff_benchmarking.jl
@@ -40,6 +40,6 @@ function benchmark_ForwardDiff_chunks(ℓ;
     map(chunks) do chunk
         ∇ℓ = ADgradient(Val(:ForwardDiff), ℓ; chunk = ForwardDiff.Chunk(chunk))
         markprogress && print(".")
-        chunk => @belapsed logdensity_and_gradient($(∇ℓ), $(x))
+        chunk => @belapsed logdensity_and_gradient_of($(∇ℓ), $(x))
     end
 end

--- a/src/LogDensityProblems.jl
+++ b/src/LogDensityProblems.jl
@@ -62,6 +62,7 @@ Dimension of the input vectors `x` for log density `ℓ`. See [`logdensityof`](@
 """
 function dimension end
 
+Base.@deprecate logdensity(ℓ, x) DensityInterface.logdensityof(ℓ, x)
 
 """
     logdensity_and_gradient_of(ℓ, x)


### PR DESCRIPTION
To summarize:

- Some projects, like Turing, would depend on both DensityInterface and LogDensityProblems, because both provide functionality they require (cf. https://github.com/TuringLang/Turing.jl/pull/1877).
- On a very high level, LDP provides functionality extending DI: nice handling of AD with various backends, and transformations via TransformVariables.
- On a lower level, their interfaces differ slightly but significantly in names and expectations, leading to redundancies in packages like Turing (such as having both `logdensity` and `logdensityof`...).

There [has already been talk](https://github.com/tpapp/LogDensityProblems.jl/issues/78) of making DI a "parent package" of LDP, but the idea was rejected as DI is rather new and wasn't really well established back then. 

I also don't feel comfortable messing radically with the interface of an existing package, deviating from the original considerations of the package author and surprising the existing user base, both of which make me hesitate. On the other hand, the situation as it has arisen in Turing is a bit unfortunate (even if not to the outside), and in the end, both packages are very close in what they want to cover.

Therfore, I'm opening this PR for the sake of discussion. The code as is passes all tests, but is not yet a serious proposal; you'll note that the interface is incompatibly changed in parts, and I cut some corners.

CC @oschulz @devmotion @cscherrer

---

An attempt to summarize the differences:

- DI grew out of PPL needs, with the constraint that it should work for different kinds of objects and be flexible wrt. more or less strict semantics (hence all the discussions about `DensityKind`s and base measures; care was taken that everything can also be made to work in MeasureTheory.jl in a sensible way).
- DI was also created as, and should remain, an extremely light interface package. 
- LDP incorporates an extensible and mature system to connect simple density calculation with gradients; this is strictly more than what DI does.
- However, LDP's interface for AD and the actual AD glue could be separated. 
- LDP also provides an integration of densities and TransformVariables. This is somewhat orthogonal to the rest; there are other change-of-variables packages out there.
- LDP starts from regular callable objects that _are_ densities, and extends them with transformation and AD wrappers. DI, on the other hand, always assumes special objects that are either `HasDensity` or `IsDensity`, and which do not have to be callable (evaluation is always via `logdensityof`). (But DI provides `logfuncdensity` to wrap any callable object and treat it as a density). Perhaps `IsDensity` objects could actually expected to be callable... but this is nowhere said so or agreed upon.

