### PR TITLE
RFC: Support ChangesOfVariables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,20 @@
 name = "LogDensityProblems"
 uuid = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.12.0"
+version = "0.13.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
-DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-TransformVariables = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ArgCheck = "1, 2"
 BenchmarkTools = "1"
+ChangesOfVariables = "0.1.3"
 DiffResults = "0.0, 1"
 DocStringExtensions = "0.8, 0.9"
 Requires = "0.5, 1"
@@ -24,6 +24,7 @@ julia = "1"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -33,7 +34,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+TransformVariables = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["BenchmarkTools", "Distributions", "Documenter", "ForwardDiff", "Pkg", "ReverseDiff", "StatsBase", "StatsFuns", "Test", "Tracker", "Zygote"]
+test = ["BenchmarkTools", "DiffResults", "Distributions", "Documenter", "ForwardDiff", "Pkg", "ReverseDiff", "StatsBase", "StatsFuns", "Test", "Tracker", "TransformVariables", "Zygote"]

--- a/src/TransformVariables_helpers.jl
+++ b/src/TransformVariables_helpers.jl
@@ -1,0 +1,18 @@
+using .TransformVariables: TransformVariables
+
+"""
+    TransformedLogDensity(t::TransformVariables.AbstractTransform, log_density_function)
+
+Construct a `TransformedLogDensity` with transform `TransformVariables.transform(t)` and
+log density function `log_density_function`.
+
+For the resulting log density function, `capabilities`, `logdensity`, and `dimension` are
+automatically defined.
+"""
+function TransformedLogDensity(t::TransformVariables.AbstractTransform, log_density_function)
+    return TransformedLogDensity(TransformVariables.transform(t), log_density_function)
+end
+
+function dimension(p::TransformedLogDensity{<:TransformVariables.CallableTransform})
+    return TransformVariables.dimension(p.transform.t)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,13 +238,13 @@ end
     p = TransformedLogDensity(t, logposterior)
     @test repr(p) == "TransformedLogDensity of dimension 1"
     @test dimension(p) == 1
-    @test p.transformation ≡ t
+    @test p.transform ≡ TransformVariables.transform(t)
     @test capabilities(p) == LogDensityOrder(0)
 
     # gradient of a problem
     ∇p = ADgradient(:ForwardDiff, p)
     @test dimension(∇p) == 1
-    @test parent(∇p).transformation ≡ t
+    @test parent(∇p).transform ≡ TransformVariables.transform(t)
 
     for _ in 1:100
         x = random_arg(t)
@@ -264,7 +264,7 @@ end
     ∇p = ADgradient(:ForwardDiff, p)
 
     @test dimension(p) == dimension(∇p) == TransformVariables.dimension(t)
-    @test p.transformation ≡ parent(∇p).transformation ≡ t
+    @test p.transform ≡ parent(∇p).transform ≡ TransformVariables.transform(t)
 
     for _ in 1:100
         x = random_arg(t)


### PR DESCRIPTION
This PR adds support for more general (i.e., not only TransformVariables-based) transforms in `TransformedLogDensity`, based on the ChangesOfVariables.jl interface that is supported by TransformVariables as well.

The motivation is two-fold: Generalizing `TransformedLogDensity` and removing the dependency on TransformVariables.

I'm slightly unhappy about the PR though, for three reasons:
- It is quite breaking
- I did not manage to remove TransformVariables-specific code completely but rather it is "hidden" with `@require` now
- For other, non TransformVariables-based transformations `TransformedLogDensity` does not define the whole interface automatically anymore but one has to implement `dimension(::TransformedLogDensity{<:MyTransform})` manually - which seems a bit annoying (and potentially problematic?) in some scenarios

To fix these problems I thought about
- adding a `getproperty` overload for `TransformedLogDensity{<:CallableTransform}` - but even then it would still be breaking since the type parameters change, and hence potentially dispatches break
- changing the API such that users have to pass `TransformVariables.transform(transformation)` instead of just `transformation` - but that seems a bit cumbersome and even then one still faces the problem that `dimension(t)` is not defined for generic transforms `t` (and I don't think there are plans to add something like this to the ChangesOfVariables API)
- adding an additional field `dimension::Int` such that users can pass the dimension instead of having to overload functions (and it could be populated automatically for TransformVariables-based transforms - if we allow some TransformVariables-specific code...)