### PR TITLE
deprecate TransformedLogDensity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblems"
 uuid = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/LogDensityProblems.jl
+++ b/src/LogDensityProblems.jl
@@ -159,6 +159,8 @@ struct TransformedLogDensity{T <: TransformVariables.AbstractTransform, L}
     log_density_function::L
 end
 
+Base.@deprecate_moved TransformedLogDensity "TransformedLogDensities.TransformedLogDensity"
+
 function Base.show(io::IO, ℓ::TransformedLogDensity)
     print(io, "TransformedLogDensity of dimension $(dimension(ℓ))")
 end


### PR DESCRIPTION
In preparation for https://github.com/tpapp/LogDensityProblems.jl/pull/89/.