### PR TITLE
Use `similar` in creation of DiffResults buffer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblems"
 uuid = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/AD_ForwardDiff.jl
+++ b/src/AD_ForwardDiff.jl
@@ -45,7 +45,7 @@ end
 
 function logdensity_and_gradient(fℓ::ForwardDiffLogDensity, x::AbstractVector)
     @unpack ℓ, gradientconfig = fℓ
-    buffer = _diffresults_buffer(ℓ, x)
+    buffer = _diffresults_buffer(x)
     result = ForwardDiff.gradient!(buffer, Base.Fix1(logdensity, ℓ), x, gradientconfig)
     _diffresults_extract(result)
 end

--- a/src/AD_ReverseDiff.jl
+++ b/src/AD_ReverseDiff.jl
@@ -50,7 +50,7 @@ end
 
 function logdensity_and_gradient(∇ℓ::ReverseDiffLogDensity, x::AbstractVector)
     @unpack ℓ, compiledtape = ∇ℓ
-    buffer = _diffresults_buffer(ℓ, x)
+    buffer = _diffresults_buffer(x)
     if compiledtape === nothing
         result = ReverseDiff.gradient!(buffer, Base.Fix1(logdensity, ℓ), x)
     else

--- a/src/DiffResults_helpers.jl
+++ b/src/DiffResults_helpers.jl
@@ -11,7 +11,7 @@ $(SIGNATURES)
 Allocate a DiffResults buffer for a gradient, taking the element type of `x` into account
 (heuristically).
 """
-function _diffresults_buffer(ℓ, x)
+function _diffresults_buffer(x)
     T = eltype(x)
     S = T <: Real ? float(Real) : Float64 # heuristic
     DiffResults.MutableDiffResult(zero(S), (similar(x, S), ))

--- a/src/DiffResults_helpers.jl
+++ b/src/DiffResults_helpers.jl
@@ -14,7 +14,7 @@ Allocate a DiffResults buffer for a gradient, taking the element type of `x` int
 function _diffresults_buffer(ℓ, x)
     T = eltype(x)
     S = T <: Real ? float(Real) : Float64 # heuristic
-    DiffResults.MutableDiffResult(zero(S), (similar(x, S, dimension(ℓ)), ))
+    DiffResults.MutableDiffResult(zero(S), (similar(x, S), ))
 end
 
 """

--- a/src/DiffResults_helpers.jl
+++ b/src/DiffResults_helpers.jl
@@ -25,6 +25,5 @@ constructed with [`diffresults_buffer`](@ref). Gradient is not copied as caller 
 vector.
 """
 function _diffresults_extract(diffresult::DiffResults.DiffResult)
-    # NOTE: Is this still needed?
-    DiffResults.value(diffresult)::Real, DiffResults.gradient(diffresult)
+    DiffResults.value(diffresult), DiffResults.gradient(diffresult)
 end

--- a/src/DiffResults_helpers.jl
+++ b/src/DiffResults_helpers.jl
@@ -14,7 +14,7 @@ Allocate a DiffResults buffer for a gradient, taking the element type of `x` int
 function _diffresults_buffer(ℓ, x)
     T = eltype(x)
     S = T <: Real ? float(Real) : Float64 # heuristic
-    DiffResults.MutableDiffResult(zero(S), (Vector{S}(undef, dimension(ℓ)), ))
+    DiffResults.MutableDiffResult(zero(S), (similar(x, S, dimension(ℓ)), ))
 end
 
 """
@@ -25,5 +25,6 @@ constructed with [`diffresults_buffer`](@ref). Gradient is not copied as caller 
 vector.
 """
 function _diffresults_extract(diffresult::DiffResults.DiffResult)
+    # NOTE: Is this still needed?
     DiffResults.value(diffresult)::Real, DiffResults.gradient(diffresult)
 end


### PR DESCRIPTION
Using `similar` means that we get automatic compat with several other packages, e.g. `ComponentArrays.jl` (the demo from the docs):
```julia
julia> x = ComponentVector(μ = 0.0, σ = 1.0);

julia> ℓ = ADgradient(:ForwardDiff, problem)
ForwardDiff AD wrapper for NormalPosterior{Float64}(100, -0.06359079034463508, 1.241856096172367), w/ chunk size 2

julia> LogDensityProblems.logdensity_and_gradient(ADgradient(:ForwardDiff, problem), x)[2]
ComponentVector{Float64}(μ = -6.359079034463508, σ = 25.339988478902235)

julia> ForwardDiff.gradient(Base.Fix1(LogDensityProblems.logdensity, problem), x) 
ComponentVector{Float64}(μ = -6.359079034463508, σ = 25.339988478902235)
```

Ref: https://github.com/TuringLang/AdvancedHMC.jl/pull/301