### PR TITLE
Fix for buggy `Base.isless` impl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblems"
 uuid = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/LogDensityProblems.jl
+++ b/src/LogDensityProblems.jl
@@ -38,7 +38,7 @@ end
 
 LogDensityOrder(K::Integer) = LogDensityOrder{K}()
 
-Base.isless(::LogDensityOrder{A}, ::LogDensityOrder{B}) where {A, B} = A ≤ B
+Base.isless(::LogDensityOrder{A}, ::LogDensityOrder{B}) where {A, B} = A < B
 
 """
 $(SIGNATURES)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,7 @@ Base.show(io::IO, ::TestLogDensity) = print(io, "TestLogDensity")
     @test LogDensityOrder(1) == LogDensityOrder(1)
     @test_throws ArgumentError LogDensityOrder(-1)
     @test LogDensityOrder(2) ≥ LogDensityOrder(1)
+    @test !(LogDensityOrder(1) > LogDensityOrder(1))
 end
 
 ####


### PR DESCRIPTION
Currenty we have
```julia
julia> LogDensityProblems.LogDensityOrder{0}() < LogDensityProblems.LogDensityOrder{0}()
true
```
which seems incorrect, no?

With this PR:
```julia
julia> LogDensityProblems.LogDensityOrder{0}() < LogDensityProblems.LogDensityOrder{0}()
false
```