### PR TITLE
Remove `UnPack` as a dependency and use `SimpleUnPack` in docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,16 @@
 name = "LogDensityProblems"
 uuid = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ArgCheck = "1, 2"
 DocStringExtensions = "0.8, 0.9"
-UnPack = "0.1, 1"
 julia = "1.6"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,10 +3,10 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LogDensityProblemsAD = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
+SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 TransformVariables = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 TransformedLogDensities = "f9bc47f6-f3f8-4f3b-ab21-f8bc73906f26"
-UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,7 +48,7 @@ It is useful to define a *callable* that implements this, taking some vector `x`
 
 ```@example 1
 using Random; Random.seed!(1) # hide
-using Statistics, UnPack # imported for our implementation
+using Statistics, SimpleUnPack # imported for our implementation
 
 struct NormalPosterior{T} # contains the summary statistics
     N::Int

--- a/src/LogDensityProblems.jl
+++ b/src/LogDensityProblems.jl
@@ -15,7 +15,6 @@ module LogDensityProblems
 using ArgCheck: @argcheck
 using DocStringExtensions: SIGNATURES, TYPEDEF
 using Random: AbstractRNG, default_rng
-using UnPack: @unpack
 
 ####
 #### interface for problems

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using LogDensityProblems, Test, Random
 import LogDensityProblems: capabilities, dimension, logdensity
 using LogDensityProblems: logdensity_and_gradient, LogDensityOrder
-using UnPack: @unpack
 
 ####
 #### test setup and utilities


### PR DESCRIPTION
Since `UnPack.@unpack` is based on `unpack(x, Val(key))` it can lead to a lot of undesired specializations, see e.g. https://github.com/SciML/OrdinaryDiffEq.jl/pull/1893. Therefore I put together a more lightweight macro that just calls `getproperty` in https://github.com/devmotion/SimpleUnPack.jl (by design, it has less features than UnPack.jl).

Initially I wanted to replace UnPack with SimpleUnPack in this package but then I noticed that apparently UnPack.@unpack is only used in the docs and not needed in the package itself anymore. It seems it was only used in the part that was moved to LogDensityProblemsAD. Hence I removed UnPack from the package and the tests, and only switched to SimpleUnPack in the docs.